### PR TITLE
features/rename-conversation

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -29,7 +29,7 @@ def load_and_store_conversation(st, cid: str):
     if conversation:
         st.session_state["conversation"] = conversation
         st.session_state["model"] = get_model_from_conversation(conversation)
-
+        st.session_state["cid"] = cid
 
 def controller():
     st.session_state["conversation_expanded"] = True

--- a/chat.py
+++ b/chat.py
@@ -29,7 +29,6 @@ def load_and_store_conversation(st, cid: str):
     if conversation:
         st.session_state["conversation"] = conversation
         st.session_state["model"] = get_model_from_conversation(conversation)
-        st.session_state["cid"] = cid
 
 def controller():
     st.session_state["conversation_expanded"] = True

--- a/firestore_utils.py
+++ b/firestore_utils.py
@@ -56,3 +56,9 @@ def delete_convo(convo_id):
     document_ref = db.collection("conversations").document(convo_id)
     document_ref.delete()
     print(f"Deleted document with ID: {convo_id}")
+    
+
+def update_conversation_name_by_id(cid, new_name):
+    db = get_firestore_db()
+    conversation = db.collection("conversations").document(cid)
+    conversation.update({"title": new_name})

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 from firestore_utils import delete_convo
-
+from firestore_utils import update_conversation_name_by_id
 
 def link_button(st, text, path):
     st.write(
@@ -39,7 +39,7 @@ def button_row(st, cid, conversation, selected=False):
     title = conversation.get("title", cid)
     container = st.sidebar.container()
     with container:
-        col1, col2 = st.columns([5, 1])
+        col1, col2, col3 = st.columns([5, 1, 1])
 
         with col1:
             convo_button = st.button(
@@ -60,6 +60,13 @@ def button_row(st, cid, conversation, selected=False):
                 delete_convo(cid)
                 st.experimental_rerun()
 
+        with col3:
+            rename_button = st.button("🖊️", key=f"rename_{cid}", disabled=selected, use_container_width=True)
+        
+        if rename_button:
+            rename_input = st.text_input("New Conversation Name:", value=title, key=f"rename_input_{cid}")
+            if rename_input:
+                update_conversation_name_by_id(cid, rename_input)
 
 def get_key_from_params(st, key):
     params = st.experimental_get_query_params()

--- a/utils.py
+++ b/utils.py
@@ -39,9 +39,9 @@ def button_row(st, cid, conversation, selected=False):
     title = conversation.get("title", cid)
     container = st.sidebar.container()
     with container:
-        col1, col2, col3 = st.columns([5, 1, 1])
+        col_1, col_2, col_3 = st.columns([5, 1, 1])
 
-        with col1:
+        with col_1:
             convo_button = st.button(
                 title, key=f"button_{cid}", disabled=selected, use_container_width=True
             )
@@ -49,7 +49,7 @@ def button_row(st, cid, conversation, selected=False):
                 st.session_state["cid"] = cid
                 st.experimental_rerun()
 
-        with col2:
+        with col_2:
             delete_button = st.button(
                 "🗑️",
                 key=f"delete_convo_button_{cid}",
@@ -60,13 +60,15 @@ def button_row(st, cid, conversation, selected=False):
                 delete_convo(cid)
                 st.experimental_rerun()
 
-        with col3:
+        with col_3:
             rename_button = st.button("🖊️", key=f"rename_{cid}", disabled=selected, use_container_width=True)
         
         if rename_button:
-            rename_input = st.text_input("New Conversation Name:", value=title, key=f"rename_input_{cid}")
-            if rename_input:
+            st.text_input("New Conversation Name:", value=title, key=f"rename_input_{cid}")
+            rename_input = st.session_state.get(f"rename_input_{cid}", "")
+            if rename_input != title:
                 update_conversation_name_by_id(cid, rename_input)
+                st.experimental_rerun()
 
 def get_key_from_params(st, key):
     params = st.experimental_get_query_params()

--- a/utils.py
+++ b/utils.py
@@ -61,7 +61,7 @@ def button_row(st, cid, conversation, selected=False):
                 st.experimental_rerun()
 
         with col_3:
-            rename_button = st.button("🖊️", key=f"rename_{cid}", disabled=selected, use_container_width=True)
+            rename_button = st.button("🖊️", disabled=selected, use_container_width=True)
         
         if rename_button:
             st.text_input("New Conversation Name:", value=title, key=f"rename_input_{cid}")


### PR DESCRIPTION
## What
Include an edit icon next to each chat history item that enables users to rename conversation title

## Why
- Feature parity with ChatGPT
- User's customization of conversation title to their personal liking and usage

## How
- Create a update_conversation_name_by_id(cid, new_name) function that updates conversation title in data base
- Add a button to the side bar that shows a rename box when clicked on

## Screenshot
<img width="324" alt="Screen Shot 2023-06-14 at 16 05 52" src="https://github.com/CoderPush/chatlit/assets/134991524/d5928721-1473-42e0-9146-1dcc4726b808">
<br/>
<img width="324" alt="Screen Shot 2023-06-14 at 16 06 19" src="https://github.com/CoderPush/chatlit/assets/134991524/14762f41-4bc8-41d7-93a3-6d704a56d6c2">

Disclaimer: I didn't know that chi Huyen had already done this. It's still a good learning experience tho.