### PR TITLE
features/updated-ui

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from firestore_utils import delete_convo, edit_convo
+from custom_js import render_copy_shared_convo_link
 
 
 def link_button(st, text, path):
@@ -40,12 +41,13 @@ def button_row(st, cid, conversation, selected=False):
     container = st.sidebar.container()
 
     with container:
-        col_1, col_2, col_3 = st.columns([6, 1, 1], gap="small")
-
+        col1, col2, col3, col4 = st.columns([6, 1, 1, 1], gap="small")
         is_edit_mode = st.session_state.get(f"title_button_{cid}", False)
         is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
 
-        with col_1:
+        with col1:
+            is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
+
             if not is_edit:
                 convo_button = st.button(
                     title,
@@ -53,6 +55,9 @@ def button_row(st, cid, conversation, selected=False):
                     disabled=selected,
                     use_container_width=True,
                 )
+                if convo_button and not is_edit_mode:
+                    st.session_state["cid"] = cid
+                    st.experimental_rerun()
             else:
                 st.text_input(
                     "Edit Label",
@@ -68,7 +73,17 @@ def button_row(st, cid, conversation, selected=False):
                 st.session_state[f"new_title_{cid}"] = ""
                 st.experimental_rerun()
 
-        with col_2:
+        with col2:
+            if is_edit_mode:
+                st.button(
+                    ":outbox_tray:",
+                    key=f"share_convo_button_{cid}",
+                    disabled=False,
+                    use_container_width=True,
+                    on_click=lambda: render_copy_shared_convo_link(cid),
+                )
+
+        with col3:
             if is_edit_mode:
                 st.button(
                     ":pencil2:",
@@ -77,7 +92,7 @@ def button_row(st, cid, conversation, selected=False):
                     use_container_width=True,
                 )
 
-        with col_3:
+        with col4:
             if is_edit_mode:
                 delete_button = st.button(
                     ":wastebasket:",
@@ -89,7 +104,6 @@ def button_row(st, cid, conversation, selected=False):
             if is_delete:
                 delete_convo(cid)
                 st.experimental_rerun()
-
 
     css = """
         <style>
@@ -106,7 +120,7 @@ def button_row(st, cid, conversation, selected=False):
             div.css-ocqkz7.e1tzin5v3 .stButton > button:hover {
                 color: #6e6e6e;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:first-child .stButton > button {
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:first-child .stButton > button{
                 justify-content: flex-start;
                 width: 220px;
                 overflow: hidden; 
@@ -119,12 +133,19 @@ def button_row(st, cid, conversation, selected=False):
                 -webkit-background-clip: text;
                 -webkit-text-fill-color: transparent;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton{
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton,
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton{
                 position: relative;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button {
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button,
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton > button {
                 position: absolute;
                 top: 0;
+            }
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button{
+                right: -23px;
+            }
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton > button{
                 right: -15px;
             }
         </style>

--- a/utils.py
+++ b/utils.py
@@ -54,7 +54,6 @@ def button_row(st, cid, conversation, selected=False):
                     disabled=selected,
                     use_container_width = True
                 )
-                
             else:
                 st.text_input(
                     "Edit Label",
@@ -99,7 +98,6 @@ def button_row(st, cid, conversation, selected=False):
                 if is_delete:
                     delete_convo(cid)
                     st.experimental_rerun()
-        
         else:
             with col4:
                 open_button = st.button("📂", key=f"open_convo{cid}", use_container_width = True)

--- a/utils.py
+++ b/utils.py
@@ -79,7 +79,6 @@ def button_row(st, cid, conversation, selected=False):
                     use_container_width=True,
                     on_click=lambda: render_copy_shared_convo_link(cid),
                 )
-
             with col3:
                 st.button(
                     ":pencil2:",
@@ -87,7 +86,6 @@ def button_row(st, cid, conversation, selected=False):
                     disabled=selected,
                     use_container_width=True,
                 )
-
             with col4:
                 delete_button = st.button(
                     ":wastebasket:",

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 from firestore_utils import delete_convo, edit_convo
-from custom_js import render_copy_shared_convo_link
 
 
 def link_button(st, text, path):
@@ -41,21 +40,19 @@ def button_row(st, cid, conversation, selected=False):
     container = st.sidebar.container()
 
     with container:
-        col1, col2, col3, col4 = st.columns([6, 1, 1, 1], gap="small")
+        col_1, col_2, col_3 = st.columns([6, 1, 1], gap="small")
 
-        with col1:
-            is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
+        is_edit_mode = st.session_state.get(f"title_button_{cid}", False)
+        is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
 
+        with col_1:
             if not is_edit:
                 convo_button = st.button(
                     title,
-                    key=f"button_{cid}",
+                    key=f"title_button_{cid}",
                     disabled=selected,
                     use_container_width=True,
                 )
-                if convo_button:
-                    st.session_state["cid"] = cid
-                    st.experimental_rerun()
             else:
                 st.text_input(
                     "Edit Label",
@@ -71,33 +68,28 @@ def button_row(st, cid, conversation, selected=False):
                 st.session_state[f"new_title_{cid}"] = ""
                 st.experimental_rerun()
 
-        with col2:
-            st.button(
-                ":outbox_tray:",
-                key=f"share_convo_button_{cid}",
-                disabled=False,
-                use_container_width=True,
-                on_click=lambda: render_copy_shared_convo_link(cid),
-            )
+        with col_2:
+            if is_edit_mode:
+                st.button(
+                    ":pencil2:",
+                    key=f"edit_convo_button_{cid}",
+                    disabled=selected,
+                    use_container_width=True,
+                )
 
-        with col3:
-            st.button(
-                ":pencil2:",
-                key=f"edit_convo_button_{cid}",
-                disabled=selected,
-                use_container_width=True,
-            )
-
-        with col4:
-            delete_button = st.button(
-                ":wastebasket:",
-                key=f"delete_convo_button_{cid}",
-                disabled=selected,
-                use_container_width=True,
-            )
-            if delete_button:
+        with col_3:
+            if is_edit_mode:
+                delete_button = st.button(
+                    ":wastebasket:",
+                    key=f"delete_convo_button_{cid}",
+                    disabled=selected,
+                    use_container_width=True,
+                )
+            is_delete = st.session_state.get(f"delete_convo_button_{cid}", False)
+            if is_delete:
                 delete_convo(cid)
                 st.experimental_rerun()
+
 
     css = """
         <style>
@@ -114,7 +106,7 @@ def button_row(st, cid, conversation, selected=False):
             div.css-ocqkz7.e1tzin5v3 .stButton > button:hover {
                 color: #6e6e6e;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:first-child .stButton > button{
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:first-child .stButton > button {
                 justify-content: flex-start;
                 width: 220px;
                 overflow: hidden; 
@@ -127,19 +119,12 @@ def button_row(st, cid, conversation, selected=False):
                 -webkit-background-clip: text;
                 -webkit-text-fill-color: transparent;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton,
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton{
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton{
                 position: relative;
             }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button,
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton > button {
+            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button {
                 position: absolute;
                 top: 0;
-            }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(2) .stButton > button{
-                right: -23px;
-            }
-            div.css-ocqkz7.e1tzin5v3 [data-testid="column"]:nth-child(3) .stButton > button{
                 right: -15px;
             }
         </style>

--- a/utils.py
+++ b/utils.py
@@ -53,11 +53,8 @@ def button_row(st, cid, conversation, selected=False):
                     title,
                     key=f"title_button_{cid}",
                     disabled=selected,
-                    use_container_width=True,
+                    use_container_width = True
                 )
-                if convo_button and not is_edit_mode:
-                    st.session_state["cid"] = cid
-                    st.experimental_rerun()
             else:
                 st.text_input(
                     "Edit Label",
@@ -72,9 +69,9 @@ def button_row(st, cid, conversation, selected=False):
                 edit_convo(cid, new_label=new_title)
                 st.session_state[f"new_title_{cid}"] = ""
                 st.experimental_rerun()
-
-        with col2:
-            if is_edit_mode:
+        
+        if is_edit_mode:
+            with col2:
                 st.button(
                     ":outbox_tray:",
                     key=f"share_convo_button_{cid}",
@@ -83,8 +80,7 @@ def button_row(st, cid, conversation, selected=False):
                     on_click=lambda: render_copy_shared_convo_link(cid),
                 )
 
-        with col3:
-            if is_edit_mode:
+            with col3:
                 st.button(
                     ":pencil2:",
                     key=f"edit_convo_button_{cid}",
@@ -92,18 +88,24 @@ def button_row(st, cid, conversation, selected=False):
                     use_container_width=True,
                 )
 
-        with col4:
-            if is_edit_mode:
+            with col4:
                 delete_button = st.button(
                     ":wastebasket:",
                     key=f"delete_convo_button_{cid}",
                     disabled=selected,
                     use_container_width=True,
                 )
-            is_delete = st.session_state.get(f"delete_convo_button_{cid}", False)
-            if is_delete:
-                delete_convo(cid)
-                st.experimental_rerun()
+                is_delete = st.session_state.get(f"delete_convo_button_{cid}", False)
+                if is_delete:
+                    delete_convo(cid)
+                    st.experimental_rerun()
+        
+        else:
+            with col4:
+                open_button = st.button("📂", key=f"open_convo{cid}", use_container_width = True)
+                if open_button:
+                    st.session_state["cid"] = cid
+                    st.experimental_rerun()
 
     css = """
         <style>

--- a/utils.py
+++ b/utils.py
@@ -25,7 +25,6 @@ def link_row(st, text, path, selected=False):
 
     st.write(
         f"""
-
         <a target="_self" href="{path}" style="display: block; color: inherit; text-decoration: none;" class="{class_name}">
           <div style="width: 100%; height: 100%; transition: background-color 0.3s; padding: 5px;">
           {text}

--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,7 @@ def link_row(st, text, path, selected=False):
 
     st.write(
         f"""
+        
         <a target="_self" href="{path}" style="display: block; color: inherit; text-decoration: none;" class="{class_name}">
           <div style="width: 100%; height: 100%; transition: background-color 0.3s; padding: 5px;">
           {text}
@@ -47,20 +48,20 @@ def button_row(st, cid, conversation, selected=False):
         with col1:
             is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
 
-            if not is_edit:
-                convo_button = st.button(
-                    title,
-                    key=f"title_button_{cid}",
-                    disabled=selected,
-                    use_container_width = True
-                )
-            else:
+            if is_edit:
                 st.text_input(
                     "Edit Label",
                     title,
                     key=f"new_title_{cid}",
                     max_chars=30,
                     label_visibility="collapsed",
+                )
+            else:
+                convo_button = st.button(
+                    title,
+                    key=f"title_button_{cid}",
+                    disabled=selected,
+                    use_container_width = True
                 )
 
             new_title = st.session_state.get(f"new_title_{cid}", "")

--- a/utils.py
+++ b/utils.py
@@ -54,6 +54,7 @@ def button_row(st, cid, conversation, selected=False):
                     disabled=selected,
                     use_container_width = True
                 )
+                
             else:
                 st.text_input(
                     "Edit Label",
@@ -78,6 +79,7 @@ def button_row(st, cid, conversation, selected=False):
                     use_container_width=True,
                     on_click=lambda: render_copy_shared_convo_link(cid),
                 )
+
             with col3:
                 st.button(
                     ":pencil2:",
@@ -85,6 +87,7 @@ def button_row(st, cid, conversation, selected=False):
                     disabled=selected,
                     use_container_width=True,
                 )
+
             with col4:
                 delete_button = st.button(
                     ":wastebasket:",

--- a/utils.py
+++ b/utils.py
@@ -61,7 +61,7 @@ def button_row(st, cid, conversation, selected=False):
                     title,
                     key=f"title_button_{cid}",
                     disabled=selected,
-                    use_container_width = True
+                    use_container_width=True,
                 )
 
             new_title = st.session_state.get(f"new_title_{cid}", "")
@@ -69,7 +69,7 @@ def button_row(st, cid, conversation, selected=False):
                 edit_convo(cid, new_label=new_title)
                 st.session_state[f"new_title_{cid}"] = ""
                 st.experimental_rerun()
-        
+
         if is_edit_mode:
             with col2:
                 st.button(
@@ -101,7 +101,9 @@ def button_row(st, cid, conversation, selected=False):
                     st.experimental_rerun()
         else:
             with col4:
-                open_button = st.button("📂", key=f"open_convo{cid}", use_container_width = True)
+                open_button = st.button(
+                    "📂", key=f"open_convo{cid}", use_container_width=True
+                )
                 if open_button:
                     st.session_state["cid"] = cid
                     st.experimental_rerun()


### PR DESCRIPTION
## What
This update makes share, rename, and delete conversation buttons only appear when the conversation's title is clicked on.

## Why
- Feature parity with ChatGPT
- Navigation optimization

## How
I added a variable called is_edit_mode, which is False by default and is set to True when the conversation's title is clicked on. After that, I included conditional statements that make the buttons only appear when in edit mode.

I also added an open button, which allows user to access older conversations.

## Screenshots
<img width="324" alt="Screen Shot 2023-06-17 at 23 56 49" src="https://github.com/CoderPush/chatlit/assets/134991524/9344a83a-029a-4b5c-a30d-20a70c57d281">
<br />
<img width="324" alt="Screen Shot 2023-06-17 at 21 49 13" src="https://github.com/CoderPush/chatlit/assets/134991524/adbc15b1-3cbc-4444-9b3e-d10221c03ed4">
