### PR TITLE
Input box at bottom of page

### DIFF
--- a/render_chat_form.py
+++ b/render_chat_form.py
@@ -56,6 +56,16 @@ def render_chat_stream(st):
         else:
             submit_button = submit_holder.button(label="Send")
 
+    styles = f"""
+    <style>
+        .stTextArea {{
+            position: fixed;
+            bottom: 2rem;
+        }}
+    </style>
+    """
+    st.markdown(styles, unsafe_allow_html=True)
+
     if submit_button or st.session_state["chat_form_user_input"]:
         st.session_state["generating"] = True
         submit_holder.empty()

--- a/render_chat_form.py
+++ b/render_chat_form.py
@@ -56,15 +56,25 @@ def render_chat_stream(st):
         else:
             submit_button = submit_holder.button(label="Send")
 
-    styles = f"""
-    <style>
-        .stTextArea {{
-            position: fixed;
-            bottom: 2rem;
-        }}
-    </style>
-    """
-    st.markdown(styles, unsafe_allow_html=True)
+        styles = f"""
+        <style>
+            .stTextArea {{
+                position: fixed;
+                bottom: 2rem;
+            }}
+            /* streamlit doesn't support getting widget id,
+             so this is a workaround to avoid selecting
+             sidebar's buttons */
+            .row-widget.stButton:not(section[data-testid="stSidebar"] .row-widget.stButton) {{
+                position: fixed;
+                bottom: 4rem;
+                right: 0;
+                width: 80px !important;
+                padding-right: 1rem;
+            }}
+        </style>
+        """
+        st.markdown(styles, unsafe_allow_html=True)
 
     if submit_button or st.session_state["chat_form_user_input"]:
         st.session_state["generating"] = True


### PR DESCRIPTION
## What
Add feature to center user's input box at the bottom of the page

## Why
For better user experience

## How
Use `st.markdown` to fix input box position
Reference: [How to place text box to the bottom?](https://discuss.streamlit.io/t/how-to-place-text-box-to-the-bottom/36469/11?u=hello_world)

## Demo

| Before | ![before](https://github.com/CoderPush/chatlit/assets/62679553/466305ca-64da-4159-8c7f-c4a223bbebde) |
|--------|-----------------------------------------|
| After  | ![after](https://github.com/CoderPush/chatlit/assets/62679553/ebd1652a-3ef5-4884-9844-6ffd95a2d46f) |

(I'm sorry the GIF quality is horrible - the original files were too big)

