### PR TITLE
Update .gitignore to exclude .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea
+.idea/
 
 ### Python Patch ###
 # Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea
 
 ### Python Patch ###
 # Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration


### PR DESCRIPTION
## WHAT
- Update .gitignore to exclude .idea folder.

## WHY
- Not let git monitor the workflows file.

## HOW
- Add .idea to file gitignore.

## DEMO
- Don't see local push .idea/workflows files to GitHub
![image](https://github.com/CoderPush/chatlit/assets/100370556/1b2ac28f-89e5-435d-97d7-e9b87f221e82)
