### PR TITLE
Add user's profile picture to chat messages

### DIFF
--- a/render_conversation.py
+++ b/render_conversation.py
@@ -12,6 +12,7 @@ def render_user_message(st, message, profile_url):
     """
     st.markdown(user_message, unsafe_allow_html=True)
 
+
 def render_messages(st, messages):
     user_picture_url = st.session_state.get("user_info", {}).get("picture", None)
     for i, message in enumerate(messages):

--- a/render_conversation.py
+++ b/render_conversation.py
@@ -1,24 +1,25 @@
 from firestore_utils import get_firestore_db
 
 
-def render_user_message(st, message):
+def render_user_message(st, message, profile_url):
+    # .css-nahz7x
     user_message = f"""
-        <div style="background-color: rgba(255, 227, 18, 0.2); \
-                    color: rgb(255, 255, 194);
-                    padding: 16px; \
-                    border-radius: 0.25rem; \
-                    line-height: 1.6; \
-                    font-size: 1rem;" \
-            >{message}</div>
+        <div role="alert" data-baseweb="notification" class="st-ae st-af st-ag st-ah st-ai st-aj st-ak st-ee st-am st-ed st-an st-ao st-ap st-aq st-ar st-as st-ef st-au st-av st-aw st-ax st-ay st-bb st-b0 st-b1 st-b2 st-b3 st-b4 st-b5 st-b6 st-b7"><div class="st-b8 st-b9"><div class="css-17z2rne e13vu3m50"><div class="css-1w6rlcb e12sa3f30">
+            <img src={profile_url} width=32 height=32 alt="Profile Picture">
+            <div data-testid="stMarkdownContainer" class="css-nahz7x e16nr0p34">
+                <p>{message}</p>
+            </div>
+        </div></div></div></div>
     """
     st.markdown(user_message, unsafe_allow_html=True)
 
 def render_messages(st, messages):
+    user_picture_url = st.session_state.get("user_info", {}).get("picture", None)
     for i, message in enumerate(messages):
         message_content = message.get("content")
         if message.get("role") == "user":
-            st.warning(message.get("content"), icon="👤")
-            render_user_message(st, message_content)
+            st.warning(message_content, icon="👤")
+            render_user_message(st, message_content, user_picture_url)
         elif message.get("role") == "assistant":
             st.info(message.get("content"), icon="🤖")
         elif message.get("role") == "system":

--- a/render_conversation.py
+++ b/render_conversation.py
@@ -1,10 +1,24 @@
 from firestore_utils import get_firestore_db
 
 
+def render_user_message(st, message):
+    user_message = f"""
+        <div style="background-color: rgba(255, 227, 18, 0.2); \
+                    color: rgb(255, 255, 194);
+                    padding: 16px; \
+                    border-radius: 0.25rem; \
+                    line-height: 1.6; \
+                    font-size: 1rem;" \
+            >{message}</div>
+    """
+    st.markdown(user_message, unsafe_allow_html=True)
+
 def render_messages(st, messages):
     for i, message in enumerate(messages):
+        message_content = message.get("content")
         if message.get("role") == "user":
             st.warning(message.get("content"), icon="👤")
+            render_user_message(st, message_content)
         elif message.get("role") == "assistant":
             st.info(message.get("content"), icon="🤖")
         elif message.get("role") == "system":

--- a/render_conversation.py
+++ b/render_conversation.py
@@ -2,7 +2,6 @@ from firestore_utils import get_firestore_db
 
 
 def render_user_message(st, message, profile_url):
-    # .css-nahz7x
     user_message = f"""
         <div role="alert" data-baseweb="notification" class="st-ae st-af st-ag st-ah st-ai st-aj st-ak st-ee st-am st-ed st-an st-ao st-ap st-aq st-ar st-as st-ef st-au st-av st-aw st-ax st-ay st-bb st-b0 st-b1 st-b2 st-b3 st-b4 st-b5 st-b6 st-b7"><div class="st-b8 st-b9"><div class="css-17z2rne e13vu3m50"><div class="css-1w6rlcb e12sa3f30">
             <img src={profile_url} width=32 height=32 alt="Profile Picture">
@@ -18,7 +17,6 @@ def render_messages(st, messages):
     for i, message in enumerate(messages):
         message_content = message.get("content")
         if message.get("role") == "user":
-            st.warning(message_content, icon="👤")
             render_user_message(st, message_content, user_picture_url)
         elif message.get("role") == "assistant":
             st.info(message.get("content"), icon="🤖")

--- a/render_conversation.py
+++ b/render_conversation.py
@@ -1,26 +1,35 @@
 from firestore_utils import get_firestore_db
 
 
-def render_user_message(st, message, profile_url):
-    user_message = f"""
-        <div role="alert" data-baseweb="notification" class="st-ae st-af st-ag st-ah st-ai st-aj st-ak st-ee st-am st-ed st-an st-ao st-ap st-aq st-ar st-as st-ef st-au st-av st-aw st-ax st-ay st-bb st-b0 st-b1 st-b2 st-b3 st-b4 st-b5 st-b6 st-b7"><div class="st-b8 st-b9"><div class="css-17z2rne e13vu3m50"><div class="css-1w6rlcb e12sa3f30">
-            <img src={profile_url} width=32 height=32 alt="Profile Picture">
-            <div data-testid="stMarkdownContainer" class="css-nahz7x e16nr0p34">
-                <p>{message}</p>
+def render_message(st, message, profile_url, role):
+    user_message = ""
+    if role == "user":
+        user_message = f"""
+            <div style="width: 80%; display:flex; justify-content: flex-end; margin-left: auto; background-color: rgba(146, 108, 5, 0.1); margin-bottom: 20px; border-radius: 4px; padding: 10px">
+                <div style="margin-right: 10px"><p>{message}</p></div>
+                <img src={profile_url} width=32 height=32 alt="Profile Picture">
             </div>
-        </div></div></div></div>
-    """
+        """
+    elif role == "assistant":
+        user_message = f"""
+            <div style="width: 80%; display:flex; background-color: rgba(28, 131, 225, 0.1); margin-bottom: 20px; border-radius: 4px; padding: 10px">
+                <div style="width: 32px; height: 32px">🤖</div>
+                <div style="margin-left: 10px"><p>{message}</p></div>
+            </div>
+        """
+
     st.markdown(user_message, unsafe_allow_html=True)
 
 
 def render_messages(st, messages):
     user_picture_url = st.session_state.get("user_info", {}).get("picture", None)
-    for i, message in enumerate(messages):
+
+    for _, message in enumerate(messages):
         message_content = message.get("content")
         if message.get("role") == "user":
-            render_user_message(st, message_content, user_picture_url)
+            render_message(st, message_content, user_picture_url, "user")
         elif message.get("role") == "assistant":
-            st.info(message.get("content"), icon="🤖")
+            render_message(st, message_content, "", "assistant")
         elif message.get("role") == "system":
             # don't render system messages
             pass


### PR DESCRIPTION
## What
This PR adds user's profile picture to each chat messages

## Why
After PR #24, user's profile picture is not displayed anymore

## How
- Create a custom component using `st.markdown` and `st.warning` styling
- Embed user's profile picture using `<img>`

## Demo
| Before | <img width="600" alt="Screenshot 2023-06-19 at 16 01 39 (1)" src="https://github.com/CoderPush/chatlit/assets/62679553/7921f700-0a0b-4417-9ed8-3c6f58320295"> |
|--------|-----------------------------------------|
| After  | <img width="712" alt="Screenshot 2023-06-21 at 4 33 29 PM" src="https://github.com/CoderPush/chatlit/assets/62679553/fbc1bf54-a087-4d57-ab54-e03cafd28b0f">|

## Bug
- `st.warning` styling is not replicated completely, i.e. chat message background is opaque instead of yellow
