### PR TITLE
update UI for button row

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -36,41 +36,47 @@ def link_row(st, text, path, selected=False):
     )
 
 
-def button_row(st, cid, conversation, selected=False):
+def button_row(st, cid, conversation, selected):
     title = conversation.get("title", cid)
     container = st.sidebar.container()
-
     with container:
         col1, col2, col3, col4 = st.columns([6, 1, 1, 1], gap="small")
-        is_edit_mode = st.session_state.get(f"title_button_{cid}", False)
-        is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
-
-        with col1:
-            is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
-
-            if is_edit:
-                st.text_input(
-                    "Edit Label",
-                    title,
-                    key=f"new_title_{cid}",
-                    max_chars=30,
-                    label_visibility="collapsed",
-                )
-            else:
+        if selected == False:
+            with col1:
                 convo_button = st.button(
                     title,
                     key=f"title_button_{cid}",
-                    disabled=selected,
+                    disabled=False,
                     use_container_width=True,
                 )
+                if convo_button:
+                    st.session_state["cid"] = cid
+                    st.experimental_rerun()
 
-            new_title = st.session_state.get(f"new_title_{cid}", "")
-            if new_title and new_title != title:
-                edit_convo(cid, new_label=new_title)
-                st.session_state[f"new_title_{cid}"] = ""
-                st.experimental_rerun()
+        else:
+            with col1:
+                is_edit = st.session_state.get(f"edit_convo_button_{cid}", False)
+                if not is_edit:
+                    convo_button = st.button(
+                        title,
+                        key=f"title_button_{cid}",
+                        disabled=selected,
+                        use_container_width=True,
+                    )
+                else:
+                    st.text_input(
+                        "Edit Label",
+                        title,
+                        key=f"new_title_{cid}",
+                        max_chars=30,
+                        label_visibility="collapsed",
+                    )
+                    new_title = st.session_state.get(f"new_title_{cid}", "")
+                    if new_title and new_title != title:
+                        edit_convo(cid, new_label=new_title)
+                        st.session_state[f"new_title_{cid}"] = ""
+                        st.experimental_rerun()
 
-        if is_edit_mode:
             with col2:
                 st.button(
                     ":outbox_tray:",
@@ -84,7 +90,7 @@ def button_row(st, cid, conversation, selected=False):
                 st.button(
                     ":pencil2:",
                     key=f"edit_convo_button_{cid}",
-                    disabled=selected,
+                    disabled=False,
                     use_container_width=True,
                 )
 
@@ -92,20 +98,12 @@ def button_row(st, cid, conversation, selected=False):
                 delete_button = st.button(
                     ":wastebasket:",
                     key=f"delete_convo_button_{cid}",
-                    disabled=selected,
+                    disabled=False,
                     use_container_width=True,
                 )
                 is_delete = st.session_state.get(f"delete_convo_button_{cid}", False)
                 if is_delete:
                     delete_convo(cid)
-                    st.experimental_rerun()
-        else:
-            with col4:
-                open_button = st.button(
-                    "📂", key=f"open_convo{cid}", use_container_width=True
-                )
-                if open_button:
-                    st.session_state["cid"] = cid
                     st.experimental_rerun()
 
     css = """


### PR DESCRIPTION
## What
- New UI for button row: When clicking on a conversation's title, the convo will be loaded and the edit options will appear.

## Why
- UI parity with ChatGPT
- Easy navigation

## How
Inside the button_row function, I set a conditional statement for selected. If selected is false, only the convo title is displayed and will load the convo if clicked on. If selected is true, it will show the edit options.

## Screenshots
<img width="321" alt="Screen Shot 2023-06-26 at 10 21 55" src="https://github.com/CoderPush/chatlit/assets/134991524/a4f705cc-f8f6-4693-80e9-2d06cc4caf1f">
